### PR TITLE
マイコンの測定値確認画面を追加する

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Dev",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "debug",
+            "args": [
+                "--dart-define-from-file=dart_defines/dev.json"
+            ]
+        },
+        {
+            "name": "Prod",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "debug",
+            "args": [
+                "--dart-define-from-file=dart_defines/prod.json"
+            ]
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,16 +1,5 @@
-# frontend
-
-A new Flutter project.
-
-## Getting Started
-
-This project is a starting point for a Flutter application.
-
-A few resources to get you started if this is your first Flutter project:
-
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
-
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+# 実機インストール手順
+- `flutter clean` (任意)
+- `flutter build ios --dart-define-from-file=dart_defines/prod.json` (インストールしたい環境に応じて読み込むjsonを変更する)
+- `flutter devices` (インストールしたい端末のid等を確認)
+- `flutter install -d ${id}`

--- a/dart_defines/dev.json
+++ b/dart_defines/dev.json
@@ -1,0 +1,4 @@
+{
+  "env": "dev",
+  "url": "http://localhost:8082"
+}

--- a/dart_defines/prod.json
+++ b/dart_defines/prod.json
@@ -1,0 +1,5 @@
+{
+    "env": "prod",
+    "url": "https://www.ems-engineering.jp/api"
+  }
+  

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -8,20 +8,20 @@ PODS:
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
-  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/ios`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - system_proxy (from `.symlinks/plugins/system_proxy/ios`)
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
   shared_preferences_foundation:
-    :path: ".symlinks/plugins/shared_preferences_foundation/ios"
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   system_proxy:
     :path: ".symlinks/plugins/system_proxy/ios"
 
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  shared_preferences_foundation: 297b3ebca31b34ec92be11acd7fb0ba932c822ca
+  shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
   system_proxy: bec1a5c5af67dd3e3ebf43979400a8756c04cc44
 
 PODFILE CHECKSUM: ef19549a9bc3046e7bb7d2fab4d021637c0c58a3

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -226,6 +226,7 @@
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -4,8 +4,14 @@
 <dict>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>ems-engineering.jp</key>
+			<dict>
+				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
 	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>

--- a/lib/views/home/home.dart
+++ b/lib/views/home/home.dart
@@ -150,7 +150,7 @@ Future<List<MicroController>> fetchMicroController() async {
   const String apiUrl = String.fromEnvironment("url");
 
   final response = await http
-      .get(Uri.parse('$apiUrl/api/ems/micro-controller/info'), headers: header);
+      .get(Uri.parse('$apiUrl/ems/micro-controller/info'), headers: header);
 
   List<MicroController> list = [];
   final responseList = json.decode(utf8.decode(response.bodyBytes)) as List;

--- a/lib/views/home/home.dart
+++ b/lib/views/home/home.dart
@@ -147,9 +147,10 @@ Future<List<MicroController>> fetchMicroController() async {
     'Cookie': 'ems_session=$sessionId'
   };
 
-  final response = await http.get(
-      Uri.parse('http://localhost:8082/ems/micro-controller/info'),
-      headers: header);
+  const String apiUrl = String.fromEnvironment("url");
+
+  final response = await http
+      .get(Uri.parse('$apiUrl/api/ems/micro-controller/info'), headers: header);
 
   List<MicroController> list = [];
   final responseList = json.decode(utf8.decode(response.bodyBytes)) as List;

--- a/lib/views/home/home.dart
+++ b/lib/views/home/home.dart
@@ -169,7 +169,7 @@ Future<List<MicroController>> fetchMicroController() async {
           id = value;
           break;
         case 'name':
-          if (value != "") {
+          if (value != "" && value != null) {
             name = value;
           } else {
             name = "名前設定なし";

--- a/lib/views/home/home.dart
+++ b/lib/views/home/home.dart
@@ -1,8 +1,8 @@
-import 'dart:developer';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:frontend/views/login/login.dart';
+import 'package:frontend/views/measuredData/measuredData.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:intl/intl.dart';
 import 'package:http/http.dart' as http;
@@ -108,7 +108,17 @@ class _Home extends State<Home> {
                             leading: const Icon(Icons.person),
                             title: Text(snapshot.data![index].name),
                             subtitle: Text(snapshot.data![index].macAddress),
-                            onTap: () {},
+                            onTap: () {
+                              String uuid = snapshot.data![index].uuid;
+                              if (uuid.isEmpty) return;
+                              Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                      builder: (context) => MeasuredData(
+                                            title: "測定結果",
+                                            microControllerUuid: uuid,
+                                          )));
+                            },
                           );
                         },
                       );
@@ -122,15 +132,17 @@ class _Home extends State<Home> {
 
 class MicroController {
   num id;
+  String uuid;
   String name;
   String macAddress;
-  num interval;
+  String interval;
   DateTime createdAt;
   DateTime? updatedAt;
   DateTime? deletedAt;
 
   MicroController(
       {required this.id,
+      required this.uuid,
       required this.name,
       required this.macAddress,
       required this.interval,
@@ -156,9 +168,10 @@ Future<List<MicroController>> fetchMicroController() async {
   final responseList = json.decode(utf8.decode(response.bodyBytes)) as List;
   for (var element in responseList) {
     late num id;
+    late String uuid;
     late String name;
     late String macAddress;
-    late num interval;
+    late String interval;
     late DateTime createdAt;
     DateTime? updatedAt;
     DateTime? deletedAt;
@@ -167,6 +180,9 @@ Future<List<MicroController>> fetchMicroController() async {
       switch (key) {
         case 'id':
           id = value;
+          break;
+        case 'uuid':
+          uuid = value;
           break;
         case 'name':
           if (value != "" && value != null) {
@@ -196,6 +212,7 @@ Future<List<MicroController>> fetchMicroController() async {
 
     MicroController microController = MicroController(
         id: id,
+        uuid: uuid,
         name: name,
         macAddress: macAddress,
         interval: interval,

--- a/lib/views/login/login.dart
+++ b/lib/views/login/login.dart
@@ -125,7 +125,7 @@ class _Login extends State<Login> {
 
                                   try {
                                     final response = await http.post(
-                                        Uri.parse('$apiUrl/api/ems/account/login'),
+                                        Uri.parse('$apiUrl/ems/account/login'),
                                         headers: header,
                                         body: json.encode({
                                           "email":

--- a/lib/views/login/login.dart
+++ b/lib/views/login/login.dart
@@ -120,10 +120,12 @@ class _Login extends State<Login> {
                                   Map<String, String> header = {
                                     'content-type': 'application/json'
                                   };
+                                  const String apiUrl =
+                                      String.fromEnvironment("url");
+
                                   try {
                                     final response = await http.post(
-                                        Uri.parse(
-                                            'http://localhost:8082/ems/account/login'),
+                                        Uri.parse('$apiUrl/api/ems/account/login'),
                                         headers: header,
                                         body: json.encode({
                                           "email":

--- a/lib/views/login/login.dart
+++ b/lib/views/login/login.dart
@@ -39,179 +39,166 @@ class _Login extends State<Login> {
         ],
       ),
       body: SingleChildScrollView(
-          child: SizedBox(
-              height: MediaQuery.of(context).size.height,
-              child: Center(
-                child: Container(
-                  padding: const EdgeInsets.all(30.0),
-                  child: Form(
-                    key: _formkey,
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: <Widget>[
-                        Padding(
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 8, vertical: 16),
-                          child: Container(
-                              height: 50,
-                              child: Center(
-                                child: Image.asset(
-                                  'assets/images/logo_blue.png',
-                                  fit: BoxFit.contain,
-                                ),
-                              )),
+          child: Center(
+        child: Container(
+          padding: const EdgeInsets.all(30.0),
+          child: Form(
+            key: _formkey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Padding(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 16),
+                  child: Container(
+                      height: 50,
+                      child: Center(
+                        child: Image.asset(
+                          'assets/images/logo_blue.png',
+                          fit: BoxFit.contain,
                         ),
-                        Padding(
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 8, vertical: 16),
-                          child: TextFormField(
-                            validator: (value) {
-                              String mailAddressRegExp =
-                                  r"^[a-zA-Z0-9_+-]+(.[a-zA-Z0-9_+-]+)*@([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]*\.)+[a-zA-Z]{2,}$";
-                              RegExp regExp = RegExp(mailAddressRegExp);
-                              if (value == null || value.isEmpty) {
-                                return 'ユーザー名が入力されていません';
-                              } else if (!regExp.hasMatch(value)) {
-                                return 'メールアドレスが正しく入力されていません';
-                              }
-                              return null;
-                            },
-                            decoration: const InputDecoration(
-                              labelText: 'メールアドレス',
-                            ),
-                            controller: emailInputFieldController,
-                          ),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 8, vertical: 16),
-                          child: TextFormField(
-                            validator: (value) {
-                              // ログイン画面ではセキュリティ上，パスワードの正規表現チェックを行わない
-                              if (value == null || value.isEmpty) {
-                                return 'パスワードが入力されていません';
-                              }
-                              return null;
-                            },
-                            obscureText: _isObscure,
-                            decoration: InputDecoration(
-                                labelText: 'パスワード',
-                                suffixIcon: IconButton(
-                                    icon: Icon(_isObscure
-                                        ? Icons.visibility_off
-                                        : Icons.visibility),
-                                    onPressed: () {
-                                      setState(() {
-                                        _isObscure = !_isObscure;
-                                      });
-                                    })),
-                            controller: passwordInputFieldController,
-                          ),
-                        ),
-                        Center(
-                          child: ElevatedButton(
-                              onPressed: () async {
-                                if (!_formkey.currentState!.validate()) {
-                                  ScaffoldMessenger.of(context).showSnackBar(
-                                    const SnackBar(
-                                        content: Text('入力値に誤りがあります')),
-                                  );
-                                } else {
-                                  Map<String, String> header = {
-                                    'content-type': 'application/json'
-                                  };
-                                  const String apiUrl =
-                                      String.fromEnvironment("url");
-
-                                  try {
-                                    final response = await http.post(
-                                        Uri.parse('$apiUrl/ems/account/login'),
-                                        headers: header,
-                                        body: json.encode({
-                                          "email":
-                                              emailInputFieldController.text,
-                                          "password":
-                                              passwordInputFieldController.text
-                                        }));
-
-                                    String statusCode =
-                                        response.statusCode.toString();
-
-                                    if (!mounted) {
-                                      // contextがない場合はreturn
-                                      return;
-                                    }
-                                    if (statusCode == "200") {
-                                      // ems_session=xxx の xxx の部分(UUID)を取得
-                                      final sessionId = response
-                                          .headers['set-cookie']
-                                          .toString()
-                                          .substring(12, 48);
-
-                                      // log('session ID: $sessionId');
-
-                                      final preferences =
-                                          await SharedPreferences.getInstance();
-                                      preferences.setString(
-                                          "ems_session", sessionId);
-
-                                      if (!mounted) return;
-                                      Navigator.pushReplacement(
-                                          context,
-                                          MaterialPageRoute(
-                                              builder: (context) =>
-                                                  const Home(title: "ホーム")));
-                                    } else if (statusCode == "400" ||
-                                        statusCode == "401") {
-                                      ScaffoldMessenger.of(context)
-                                          .showSnackBar(
-                                        const SnackBar(
-                                            content: Text('アカウント情報に誤りがあります。')),
-                                      );
-                                    } else if (statusCode == "500") {
-                                      // #8 catchで拾えているかの確認が取れるまで，重複するが拾えるようにする
-                                      ScaffoldMessenger.of(context)
-                                          .showSnackBar(
-                                        const SnackBar(
-                                            content: Text(
-                                                '問題が発生しました。時間をおいて再度お試しください。')),
-                                      );
-                                    }
-                                  } catch (exception) {
-                                    log("Error: ${exception.toString()}");
-                                    ScaffoldMessenger.of(context).showSnackBar(
-                                      const SnackBar(
-                                          content: Text(
-                                              '問題が発生しました。時間をおいて再度お試しください。')),
-                                    );
-                                  }
-                                }
-                              },
-                              style: ButtonStyle(
-                                  backgroundColor: MaterialStateProperty.all(
-                                      const Color.fromRGBO(
-                                          153, 153, 153, 100))),
-                              child: const Text('ログイン')),
-                        ),
-                        Center(
-                          child: ElevatedButton(
-                              onPressed: () {
-                                Navigator.pushReplacement(
-                                    context,
-                                    MaterialPageRoute(
-                                        builder: (context) =>
-                                            const Register(title: "新規登録")));
-                              },
-                              style: ButtonStyle(
-                                  backgroundColor: MaterialStateProperty.all(
-                                      const Color.fromRGBO(46, 109, 186, 80))),
-                              child: const Text('新規登録はこちら')),
-                        ),
-                      ],
+                      )),
+                ),
+                Padding(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 16),
+                  child: TextFormField(
+                    validator: (value) {
+                      String mailAddressRegExp =
+                          r"^[a-zA-Z0-9_+-]+(.[a-zA-Z0-9_+-]+)*@([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]*\.)+[a-zA-Z]{2,}$";
+                      RegExp regExp = RegExp(mailAddressRegExp);
+                      if (value == null || value.isEmpty) {
+                        return 'ユーザー名が入力されていません';
+                      } else if (!regExp.hasMatch(value)) {
+                        return 'メールアドレスが正しく入力されていません';
+                      }
+                      return null;
+                    },
+                    decoration: const InputDecoration(
+                      labelText: 'メールアドレス',
                     ),
+                    controller: emailInputFieldController,
                   ),
                 ),
-              ))),
+                Padding(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 16),
+                  child: TextFormField(
+                    validator: (value) {
+                      // ログイン画面ではセキュリティ上，パスワードの正規表現チェックを行わない
+                      if (value == null || value.isEmpty) {
+                        return 'パスワードが入力されていません';
+                      }
+                      return null;
+                    },
+                    obscureText: _isObscure,
+                    decoration: InputDecoration(
+                        labelText: 'パスワード',
+                        suffixIcon: IconButton(
+                            icon: Icon(_isObscure
+                                ? Icons.visibility_off
+                                : Icons.visibility),
+                            onPressed: () {
+                              setState(() {
+                                _isObscure = !_isObscure;
+                              });
+                            })),
+                    controller: passwordInputFieldController,
+                  ),
+                ),
+                Center(
+                  child: ElevatedButton(
+                      onPressed: () async {
+                        if (!_formkey.currentState!.validate()) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(content: Text('入力値に誤りがあります')),
+                          );
+                        } else {
+                          Map<String, String> header = {
+                            'content-type': 'application/json'
+                          };
+                          const String apiUrl = String.fromEnvironment("url");
+
+                          try {
+                            final response = await http.post(
+                                Uri.parse('$apiUrl/ems/account/login'),
+                                headers: header,
+                                body: json.encode({
+                                  "email": emailInputFieldController.text,
+                                  "password": passwordInputFieldController.text
+                                }));
+
+                            String statusCode = response.statusCode.toString();
+
+                            if (!mounted) {
+                              // contextがない場合はreturn
+                              return;
+                            }
+                            if (statusCode == "200") {
+                              // ems_session=xxx の xxx の部分(UUID)を取得
+                              final sessionId = response.headers['set-cookie']
+                                  .toString()
+                                  .substring(12, 48);
+
+                              // log('session ID: $sessionId');
+
+                              final preferences =
+                                  await SharedPreferences.getInstance();
+                              preferences.setString("ems_session", sessionId);
+
+                              if (!mounted) return;
+                              Navigator.pushReplacement(
+                                  context,
+                                  MaterialPageRoute(
+                                      builder: (context) =>
+                                          const Home(title: "ホーム")));
+                            } else if (statusCode == "400" ||
+                                statusCode == "401") {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(
+                                    content: Text('アカウント情報に誤りがあります。')),
+                              );
+                            } else if (statusCode == "500") {
+                              // #8 catchで拾えているかの確認が取れるまで，重複するが拾えるようにする
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(
+                                    content:
+                                        Text('問題が発生しました。時間をおいて再度お試しください。')),
+                              );
+                            }
+                          } catch (exception) {
+                            log("Error: ${exception.toString()}");
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                  content: Text('問題が発生しました。時間をおいて再度お試しください。')),
+                            );
+                          }
+                        }
+                      },
+                      style: ButtonStyle(
+                          backgroundColor: MaterialStateProperty.all(
+                              const Color.fromRGBO(153, 153, 153, 100))),
+                      child: const Text('ログイン')),
+                ),
+                Center(
+                  child: ElevatedButton(
+                      onPressed: () {
+                        Navigator.pushReplacement(
+                            context,
+                            MaterialPageRoute(
+                                builder: (context) =>
+                                    const Register(title: "新規登録")));
+                      },
+                      style: ButtonStyle(
+                          backgroundColor: MaterialStateProperty.all(
+                              const Color.fromRGBO(46, 109, 186, 80))),
+                      child: const Text('新規登録はこちら')),
+                ),
+              ],
+            ),
+          ),
+        ),
+      )),
     );
   }
 }

--- a/lib/views/measuredData/measuredData.dart
+++ b/lib/views/measuredData/measuredData.dart
@@ -1,0 +1,638 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:frontend/views/login/login.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:http/http.dart' as http;
+import 'package:fl_chart/fl_chart.dart';
+
+class MeasuredData extends StatefulWidget {
+  const MeasuredData(
+      {Key? key, required this.title, required this.microControllerUuid})
+      : super(key: key);
+
+  final String title;
+  final String microControllerUuid;
+
+  @override
+  State<MeasuredData> createState() => _MeasuredData();
+}
+
+class _MeasuredData extends State<MeasuredData> {
+  late Future<MeasuredDataState>? microControllerList;
+  bool showSdiChart = true;
+  String targetSdiVariable = sdi12Variables.first;
+  String targetEnvironmentVariable = environmentVariables.first;
+
+  // response を state に追加
+  Future<MeasuredDataState> getMeasuredData() async {
+    MeasuredDataState response =
+        await fetchMeasuredData(widget.microControllerUuid);
+    return response;
+  }
+
+  setCharVariety(String value) {
+    if (value == "SDI-12データ") {
+      showSdiChart = true;
+    } else {
+      showSdiChart = false;
+    }
+  }
+
+  setSdiVariable(String value) {
+    targetSdiVariable = value;
+  }
+
+  setEnvironmentVariable(String value) {
+    targetEnvironmentVariable = value;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          title: Text(widget.title),
+          backgroundColor: const Color.fromRGBO(99, 99, 99, 100),
+          actions: [
+            Container(
+              padding: const EdgeInsets.all(10),
+              child: IconButton(
+                  icon: const Icon(Icons.logout),
+                  onPressed: () {
+                    AlertDialog alert = AlertDialog(
+                        title: const Text("確認"),
+                        content: const Text("ログアウトします。よろしいですか？"),
+                        actions: <Widget>[
+                          // ボタン領域
+                          ElevatedButton(
+                            child: const Text("Cancel"),
+                            onPressed: () => Navigator.pop(context),
+                          ),
+                          ElevatedButton(
+                            child: const Text("OK"),
+                            onPressed: () async {
+                              final preferences =
+                                  await SharedPreferences.getInstance();
+                              preferences.clear(); // セッション情報の削除
+
+                              if (!mounted) return;
+                              Navigator.pop(context);
+                              Navigator.pushReplacement(
+                                  context,
+                                  MaterialPageRoute(
+                                      builder: (context) =>
+                                          const Login(title: "ログイン")));
+                            },
+                          ),
+                        ]);
+                    showDialog(
+                        context: context,
+                        builder: (BuildContext context) {
+                          return alert;
+                        });
+                  }),
+            ),
+            Container(
+                padding: const EdgeInsets.all(10),
+                child: Image.asset(
+                  "assets/images/logo_white.png",
+                  fit: BoxFit.contain,
+                )),
+          ],
+        ),
+        body: Container(
+          padding:
+              const EdgeInsets.only(left: 10, top: 20, right: 10, bottom: 40),
+          child: Column(children: [
+            Expanded(
+              child: Container(
+                  padding: const EdgeInsets.all(15),
+                  height: 600,
+                  width: double.infinity,
+                  child: FutureBuilder<MeasuredDataState?>(
+                      future: getMeasuredData(),
+                      builder: (context, snapshot) {
+                        if (snapshot.connectionState != ConnectionState.done) {
+                          return const Center(
+                            child: CircularProgressIndicator(),
+                          );
+                        }
+                        if (snapshot.hasData &&
+                            snapshot.connectionState == ConnectionState.done) {
+                          return LineChart(mainData(
+                              snapshot.data,
+                              showSdiChart,
+                              showSdiChart
+                                  ? targetSdiVariable
+                                  : targetEnvironmentVariable));
+                        } else {
+                          return Text(snapshot.error.toString());
+                        }
+                      })),
+            ),
+            Column(
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const SizedBox(
+                      width: 100,
+                      child: Text("表示する種類"),
+                    ),
+                    const Padding(padding: EdgeInsets.all(10)),
+                    Container(
+                      padding: const EdgeInsets.only(left: 10),
+                      decoration: BoxDecoration(
+                        border: Border.all(
+                            color: const Color.fromARGB(80, 0, 0, 0)),
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                      child: DropdownButton(
+                        underline: Container(),
+                        items: chartVariety
+                            .map<DropdownMenuItem<String>>((String value) {
+                          return DropdownMenuItem<String>(
+                            value: value,
+                            child: Text(value),
+                          );
+                        }).toList(),
+                        value: showSdiChart ? "SDI-12データ" : "環境データ",
+                        onChanged: (String? value) {
+                          setState(() {
+                            setCharVariety(value!);
+                          });
+                        },
+                      ),
+                    )
+                  ],
+                ),
+                const Padding(padding: EdgeInsets.all(10)),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Container(
+                      child: const Text("表示する項目"),
+                    ),
+                    const Padding(padding: EdgeInsets.all(10)),
+                    Container(
+                      padding: const EdgeInsets.only(left: 10),
+                      decoration: BoxDecoration(
+                        border: Border.all(
+                            color: const Color.fromARGB(80, 0, 0, 0)),
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                      child: DropdownButton(
+                        underline: Container(),
+                        items: generateListForDropDownMenu(showSdiChart),
+                        value: showSdiChart
+                            ? targetSdiVariable
+                            : targetEnvironmentVariable,
+                        onChanged: (String? value) {
+                          setState(() {
+                            if (showSdiChart) {
+                              setSdiVariable(value!);
+                            } else {
+                              setEnvironmentVariable(value!);
+                            }
+                          });
+                        },
+                      ),
+                    )
+                  ],
+                ),
+              ],
+            ),
+          ]),
+        ));
+  }
+}
+
+/// ドロップダウンリスト用選択肢
+const List<String> chartVariety = <String>["SDI-12データ", "環境データ"];
+
+/// ドロップダウンリスト用選択肢
+const List<String> sdi12Variables = <String>[
+  '体積含水率',
+  'バルク比誘電率',
+  '地温',
+  'バルク電気伝導度',
+  '土壌間隙水電気伝導度',
+  '重力加速度(X)',
+  '重力加速度(Y)',
+  '重力加速度(Z)'
+];
+
+/// ドロップダウンリスト用選択肢
+const List<String> environmentVariables = <String>[
+  '大気圧',
+  '気温',
+  '相対湿度',
+  '二酸化炭素濃度',
+  '揮発性有機化合物',
+  'アナログ値'
+];
+
+/// ドロップダウンリストの値を基に，グラフ表示用データを生成する
+List<DropdownMenuItem<String>> generateListForDropDownMenu(bool showSdiChart) {
+  if (showSdiChart) {
+    return sdi12Variables.map<DropdownMenuItem<String>>((String value) {
+      return DropdownMenuItem<String>(
+        value: value,
+        child: Text(value),
+      );
+    }).toList();
+  } else {
+    return environmentVariables.map<DropdownMenuItem<String>>((String value) {
+      return DropdownMenuItem<String>(
+        value: value,
+        child: Text(value),
+      );
+    }).toList();
+  }
+}
+
+Future<MeasuredDataState> fetchMeasuredData(String microControllerUuid) async {
+  final preferences = await SharedPreferences.getInstance();
+  final sessionId = preferences.getString("ems_session");
+  Map<String, String> header = {
+    'content-type': 'application/json',
+    'Cookie': 'ems_session=$sessionId'
+  };
+
+  const String apiUrl = String.fromEnvironment("url");
+
+  final response = await http.get(
+      Uri.parse(
+          '$apiUrl/ems/measured-data?microControllerUuid=$microControllerUuid'),
+      headers: header);
+
+  final body = json.decode(response.body);
+
+  List<Sdi12DataState> sdi12Data = body["sdi12Data"]
+      .map<Sdi12DataState>((dynamic item) => Sdi12DataState.fromJson(item))
+      .toList();
+
+  List<EnvironmentalDataState> environmentalData = body["environmentalData"]
+      .map<EnvironmentalDataState>(
+          (dynamic item) => EnvironmentalDataState.fromJson(item))
+      .toList();
+
+  List<VoltageDataState> voltageData = body["voltageData"]
+      .map<VoltageDataState>((dynamic item) => VoltageDataState.fromJson(item))
+      .toList();
+
+  final measuredDataState = MeasuredDataState(
+      sdi12Data: sdi12Data,
+      environmentalData: environmentalData,
+      voltageData: voltageData);
+
+  return Future.value(measuredDataState);
+}
+
+LineChartData mainData(MeasuredDataState? measuredDataState, bool sdiChart,
+    String selectedVariable) {
+  return LineChartData(
+      // タッチ操作時の設定
+      lineTouchData: const LineTouchData(
+        handleBuiltInTouches: true, // タッチ時のアクションの有無
+        getTouchedSpotIndicator: defaultTouchedIndicators, // インジケーターの設定
+        // ツールチップの設定
+        touchTooltipData: LineTouchTooltipData(
+          getTooltipItems: defaultLineTooltipItem, // 表示文字設定
+          tooltipBgColor: Colors.white, // 背景の色
+          tooltipRoundedRadius: 2.0, // 角丸
+        ),
+      ),
+
+      // 背景のグリッド線の設定
+      gridData: FlGridData(
+        show: true, // 背景のグリッド線の有無
+        drawVerticalLine: true, // 水平方向のグリッド線の有無
+        //horizontalInterval: 1.0, // 背景グリッドの横線間隔
+        //verticalInterval: 1.0, // 背景グリッドの縦線間隔
+        // 背景グリッドの横線設定
+        getDrawingHorizontalLine: (value) {
+          return const FlLine(
+            color: Color.fromARGB(80, 0, 0, 0),
+            strokeWidth: 1.0, // 線の太さ
+          );
+        },
+        // 背景グリッドの縦線設定
+        getDrawingVerticalLine: (value) {
+          return const FlLine(
+            color: Color.fromARGB(80, 0, 0, 0),
+            strokeWidth: 1.0, // 線の太さ
+          );
+        },
+      ),
+
+      // グラフのタイトル設定
+      titlesData: FlTitlesData(
+        show: true, // タイトルの有無
+        rightTitles: AxisTitles(),
+        topTitles: AxisTitles(),
+        // 下側のタイトル設定
+        bottomTitles: const AxisTitles(
+          // タイトル名
+          axisNameWidget: Text(
+            "DOY",
+            style: TextStyle(
+              color: Color(0xff68737d),
+            ),
+          ),
+          axisNameSize: 20.0, //タイトルの表示エリアの幅
+          // サイドタイトルの設定
+          sideTitles: SideTitles(
+            showTitles: true, // サイドタイトルの有無
+            interval: 1.0, // サイドタイトルの表示間隔
+            reservedSize: 50.0, // サイドタイトルの表示エリアの幅
+            //getTitlesWidget: bottomTitleWidgets, // サイドタイトルの表示内容
+          ),
+        ),
+        leftTitles: AxisTitles(
+          axisNameWidget: Text(
+            selectedVariable,
+            style: const TextStyle(
+              color: Color(0xff68737d),
+            ),
+          ),
+          axisNameSize: 20.0, //タイトルの表示エリアの幅
+          sideTitles: const SideTitles(
+            showTitles: true, // サイドタイトルの表示・非表示
+            interval: 1.0, // サイドタイトルの表示間隔
+            reservedSize: 50.0, // サイドタイトルの表示エリアの幅
+            //getTitlesWidget: leftTitleWidgets,
+          ),
+        ),
+      ),
+
+      // グラフの外枠線
+      borderData: FlBorderData(
+        show: true, // 外枠線の有無
+        border: Border.all(
+          color: const Color(0xff37434d),
+        ),
+      ),
+
+      // グラフのx軸y軸のの表示数(最大値)
+      // minX: 0.0,
+      // maxX: 6.0,
+      // minY: 0.0,
+      // maxY: 6.0,
+      lineBarsData:
+          generateChartDate(measuredDataState!, sdiChart, selectedVariable));
+}
+
+/// グラフ全体のデータを生成する処理
+List<LineChartBarData> generateChartDate(
+    MeasuredDataState state, bool showSdiChart, String selectedVariable) {
+  if (showSdiChart) {
+    return state.sdi12Data.map<LineChartBarData>((Sdi12DataState state) {
+      return LineChartBarData(
+        // 表示する座標のリスト
+        spots: state.dataList
+            .map((Sdi12Data sdi12data) =>
+                generateSdiData(sdi12data, selectedVariable))
+            .toList(),
+        // チャート線を曲線にするか折れ線にするか
+        isCurved: false,
+        barWidth: 1.0, // チャート線幅
+        isStrokeCapRound: false, // チャート線の開始と終了がQubicかRoundか（？）
+        dotData: FlDotData(
+          show: true, // 座標にドット表示の有無
+          // ドットの詳細設定
+          getDotPainter: (spot, percent, barData, index) =>
+              // ドットの詳細設定
+              FlDotCirclePainter(
+            radius: 2.0,
+            color: Colors.blue,
+            strokeWidth: 2.0,
+            strokeColor: Colors.blue,
+          ),
+        ),
+        // チャート線下部に色を付ける場合の設定
+        belowBarData: BarAreaData(
+          show: false,
+        ),
+      );
+    }).toList();
+  } else {
+    return [
+      LineChartBarData(
+        // 表示する座標のリスト
+        spots: state.environmentalData
+            .map<FlSpot>((EnvironmentalDataState state) =>
+                generateEnvironmentData(state, selectedVariable))
+            .toList(),
+        // チャート線を曲線にするか折れ線にするか
+        isCurved: false,
+        barWidth: 1.0, // チャート線幅
+        isStrokeCapRound: false, // チャート線の開始と終了がQubicかRoundか（？）
+        dotData: FlDotData(
+          show: true, // 座標にドット表示の有無
+          // ドットの詳細設定
+          getDotPainter: (spot, percent, barData, index) =>
+              // ドットの詳細設定
+              FlDotCirclePainter(
+            radius: 2.0,
+            color: Colors.blue,
+            strokeWidth: 2.0,
+            strokeColor: Colors.blue,
+          ),
+        ),
+        // チャート線下部に色を付ける場合の設定
+        belowBarData: BarAreaData(
+          show: false,
+        ),
+      )
+    ];
+  }
+}
+
+/// SDI-12データのグラフのポイントを生成する処理
+FlSpot generateSdiData(Sdi12Data sdiData, String targetSdiVariable) {
+  switch (targetSdiVariable) {
+    case "体積含水率":
+      return FlSpot(
+          double.parse(sdiData.dayOfYear!), double.parse((sdiData.vwc!)));
+    case "バルク比誘電率":
+      return FlSpot(
+          double.parse(sdiData.dayOfYear!), double.parse((sdiData.brp!)));
+    case "地温":
+      return FlSpot(
+          double.parse(sdiData.dayOfYear!), double.parse((sdiData.soilTemp!)));
+    case "バルク電気電動度":
+      return FlSpot(
+          double.parse(sdiData.dayOfYear!), double.parse((sdiData.sbec!)));
+    case "土壌感間隙水電気伝導度":
+      return FlSpot(
+          double.parse(sdiData.dayOfYear!), double.parse((sdiData.spwec!)));
+    case "重力加速度(X)":
+      return FlSpot(
+          double.parse(sdiData.dayOfYear!), double.parse((sdiData.gax!)));
+    case "重力加速度(Y)":
+      return FlSpot(
+          double.parse(sdiData.dayOfYear!), double.parse((sdiData.gay!)));
+    case "重力加速度(Z)":
+      return FlSpot(
+          double.parse(sdiData.dayOfYear!), double.parse((sdiData.gaz!)));
+    default:
+      return const FlSpot(0, 0);
+  }
+}
+
+/// 環境データのグラフのポイントを生成する処理
+FlSpot generateEnvironmentData(
+    EnvironmentalDataState state, String targetEnvironmentVariable) {
+  switch (targetEnvironmentVariable) {
+    case "大気圧":
+      return FlSpot(
+          double.parse(state.dayOfYear), double.parse((state.airPress!)));
+    case "気温":
+      return FlSpot(double.parse(state.dayOfYear), double.parse((state.temp!)));
+    case "相対湿度":
+      return FlSpot(double.parse(state.dayOfYear), double.parse((state.humi!)));
+    case "二酸化炭素濃度":
+      return FlSpot(
+          double.parse(state.dayOfYear), double.parse((state.co2Concent!)));
+    case "揮発性有機化合物":
+      return FlSpot(double.parse(state.dayOfYear), double.parse((state.tvoc!)));
+    case "アナログ値(X)":
+      return FlSpot(
+          double.parse(state.dayOfYear), double.parse((state.analogValue!)));
+    default:
+      return const FlSpot(0, 0);
+  }
+}
+
+/// SDI-12のデータクラス
+class Sdi12Data {
+  num? measuredDataMasterId;
+  String? dayOfYear;
+  String? vwc;
+  String? soilTemp;
+  String? brp;
+  String? sbec;
+  String? spwec;
+  String? gax;
+  String? gay;
+  String? gaz;
+  String? createdAt;
+  String? updatedAt;
+  String? deletedAt;
+
+  Sdi12Data.fromJson(Map<String, dynamic> json)
+      : measuredDataMasterId = json["measuredDataMasterId"],
+        dayOfYear = json["dayOfYear"],
+        vwc = json["vwc"],
+        soilTemp = json["soilTemp"],
+        brp = json["brp"],
+        sbec = json["sbec"],
+        spwec = json["spwec"],
+        gax = json["gax"],
+        gay = json["gay"],
+        gaz = json["gaz"],
+        createdAt = json["createdAt"],
+        updatedAt = json["updatedAt"],
+        deletedAt = json["deletedAt"];
+}
+
+/// アドレス毎のSDI-12データを保持するクラス
+class Sdi12DataState {
+  String sdiAddress;
+  List<Sdi12Data> dataList;
+
+  Sdi12DataState({required this.sdiAddress, required this.dataList});
+
+  Sdi12DataState.fromJson(Map<String, dynamic> json)
+      : sdiAddress = json["sdiAddress"],
+        dataList = json["dataList"]
+            .map<Sdi12Data>((dynamic item) => Sdi12Data.fromJson(item))
+            .toList();
+}
+
+/// 電圧データクラス
+class VoltageDataState {
+  num measuredDataMasterId;
+  String dayOfYear;
+  String voltage;
+  String createdAt;
+  String updatedAt;
+  String? deletedAt;
+  VoltageDataState(
+      {required this.measuredDataMasterId,
+      required this.dayOfYear,
+      required this.voltage,
+      required this.createdAt,
+      required this.updatedAt,
+      required this.deletedAt});
+
+  VoltageDataState.fromJson(Map<String, dynamic> json)
+      : measuredDataMasterId = json["measuredDataMasterId"],
+        dayOfYear = json["dayOfYear"],
+        voltage = json["voltage"],
+        createdAt = json["createdAt"],
+        updatedAt = json["updatedAt"],
+        deletedAt = json["deletedAt"];
+}
+
+/// 環境データクラス
+class EnvironmentalDataState {
+  num measuredDataMasterId;
+  String dayOfYear;
+  String? airPress;
+  String? temp;
+  String? humi;
+  String? co2Concent;
+  String? tvoc;
+  String? analogValue;
+  String createdAt;
+  String updatedAt;
+  String? deletedAt;
+  EnvironmentalDataState(
+      {required this.measuredDataMasterId,
+      required this.dayOfYear,
+      required this.airPress,
+      required this.temp,
+      required this.humi,
+      required this.co2Concent,
+      required this.tvoc,
+      required this.analogValue,
+      required this.createdAt,
+      required this.updatedAt,
+      required this.deletedAt});
+
+  EnvironmentalDataState.fromJson(Map<String, dynamic> json)
+      : measuredDataMasterId = json["measuredDataMasterId"],
+        dayOfYear = json["dayOfYear"],
+        airPress = json["airPress"],
+        temp = json["temp"],
+        humi = json["humi"],
+        co2Concent = json["co2Concent"],
+        tvoc = json["tvoc"],
+        analogValue = json["analogValue"],
+        createdAt = json["createdAt"],
+        updatedAt = json["updatedAt"],
+        deletedAt = json["deletedAt"];
+}
+
+/// 測定データクラス
+class MeasuredDataState {
+  List<Sdi12DataState> sdi12Data;
+  List<EnvironmentalDataState> environmentalData;
+  List<VoltageDataState> voltageData;
+  MeasuredDataState(
+      {required this.sdi12Data,
+      required this.environmentalData,
+      required this.voltageData});
+
+  MeasuredDataState.fromJson(Map<String, dynamic> json)
+      : sdi12Data = json["sdi12Data"],
+        environmentalData = json["environmentalData"],
+        voltageData = json["voltageData"];
+}

--- a/lib/views/register/register.dart
+++ b/lib/views/register/register.dart
@@ -159,7 +159,7 @@ class _Register extends State<Register> {
                           const String apiUrl = String.fromEnvironment("url");
                           try {
                             final response = await http.post(
-                                Uri.parse('$apiUrl/api/ems/account/register'),
+                                Uri.parse('$apiUrl/ems/account/register'),
                                 headers: header,
                                 body: json.encode({
                                   "email": emailInputFieldController.text,

--- a/lib/views/register/register.dart
+++ b/lib/views/register/register.dart
@@ -156,10 +156,10 @@ class _Register extends State<Register> {
                           Map<String, String> header = {
                             'content-type': 'application/json'
                           };
+                          const String apiUrl = String.fromEnvironment("url");
                           try {
                             final response = await http.post(
-                                Uri.parse(
-                                    'http://localhost:8082/ems/account/register'),
+                                Uri.parse('$apiUrl/api/ems/account/register'),
                                 headers: header,
                                 body: json.encode({
                                   "email": emailInputFieldController.text,

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,0 +1,23 @@
+PODS:
+  - FlutterMacOS (1.0.0)
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - FlutterMacOS (from `Flutter/ephemeral`)
+  - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
+
+EXTERNAL SOURCES:
+  FlutterMacOS:
+    :path: Flutter/ephemeral
+  shared_preferences_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
+
+SPEC CHECKSUMS:
+  FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
+  shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
+
+PODFILE CHECKSUM: 353c8bcc5d5b0994e508d035b5431cfe18c1dea7
+
+COCOAPODS: 1.11.3

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -97,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.5"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,26 +5,26 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: d6347d54a2d8028e0437e3c099f66fdb8ae02c4720c1e7534c9f24c10351f85d
+      sha256: "0c8368c9b3f0abbc193b9d6133649a614204b528982bebc7026372d61677ce3a"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.6"
+    version: "3.3.7"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: "4cab82a83ffef80b262ddedf47a0a8e56ee6fbf7fe21e6e768b02792034dd440"
+      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.2"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -37,18 +37,18 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      sha256: "3d1505d91afa809d177efd4eed5bb0eb65805097a1463abdd2add076effae311"
+      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   cli_util:
     dependency: transitive
     description:
@@ -69,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.1"
   convert:
     dependency: transitive
     description:
@@ -85,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: crypto
-      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: a38574032c5f1dd06c4aee541789906c12ccaab8ba01446e800d9c5b79c4a978
+      sha256: ed5337a5660c506388a9f012be0288fb38b49020ce2b45fe1f8b8323fe429f99
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   file:
     dependency: transitive
     description:
@@ -129,6 +129,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.4"
+  fl_chart:
+    dependency: "direct main"
+    description:
+      name: fl_chart
+      sha256: c1e26c7e48496be85104c16c040950b0436674cdf0737f3f6e95511b2529b592
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.63.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -138,18 +146,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_launcher_icons
-      sha256: "8546a9b9510e1a260b8d55fb2d07096e8a8552c6a2c2bf529100344894b2b41a"
+      sha256: "526faf84284b86a4cb36d20a5e45147747b7563d921373d4ee0559c54fcdbcea"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.13.1"
   flutter_lints:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      sha256: "2118df84ef0c3ca93f96123a616ae8540879991b8b57af2f81b76a7ada49b2a4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -164,10 +172,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: "6aa2946395183537c8b880962d935877325d6a09a2867c3970c05c0fed6ac482"
+      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.5"
+    version: "0.13.6"
   http_parser:
     dependency: transitive
     description:
@@ -180,50 +188,50 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: "483a389d6ccb292b570c31b3a193779b1b0178e7eb571986d9a49904b6861227"
+      sha256: a72242c9a0ffb65d03de1b7113bc4e189686fc07c7147b8b41811d0dd0e0d9bf
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.15"
+    version: "4.0.17"
   intl:
     dependency: "direct main"
     description:
       name: intl
-      sha256: a3715e3bc90294e971cb7dc063fbf3cd9ee0ebf8604ffeafabd9e6f16abbdbe6
+      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.0"
+    version: "0.18.1"
   js:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
+      sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
+    version: "4.8.1"
   lints:
     dependency: transitive
     description:
       name: lints
-      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
@@ -236,50 +244,50 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   path:
     dependency: "direct main"
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
-      sha256: "2e32f1640f07caef0d3cb993680f181c79e54a3827b997d5ee221490d131fbd9"
+      sha256: ba2b77f0c52a33db09fc8caf85b12df691bf28d983e84cf87ff6d693cfa007b3
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.8"
+    version: "2.2.0"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      sha256: f0abc8ebd7253741f05488b4813d936b4d07c6bae3e86148a09e342ee4b08e76
+      sha256: bced5679c7df11190e1ddc35f3222c858f328fff85c3942e46e7f5589bf9eb84
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.5"
+    version: "2.1.0"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
-      sha256: bcabbe399d4042b8ee687e17548d5d3f527255253b4a639f5f8d2094a9c2b45c
+      sha256: ee0e0d164516b90ae1f970bdf29f726f1aa730d7cfc449ecc74c495378b705da
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.2.0"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
-      sha256: "49392a45ced973e8d94a85fdb21293fbb40ba805fc49f2965101ae748a3683b4"
+      sha256: cb3798bef7fc021ac45b308f4b51208a152792445cce0448c9a4ba5879dd8750
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.0"
+    version: "5.4.0"
   platform:
     dependency: transitive
     description:
@@ -292,82 +300,74 @@ packages:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      sha256: dbf0f707c78beedc9200146ad3cb0ab4d5da13c246336987be6940f026500d3a
+      sha256: "43798d895c929056255600343db8f049921cbec94d31ec87f1dc5c16c01935dd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.5"
   pointycastle:
     dependency: transitive
     description:
       name: pointycastle
-      sha256: c3120a968135aead39699267f4c74bc9a08e4e909e86bc1b0af5bfd78691123c
+      sha256: "7c1e5f0d23c9016c5bbd8b1473d0d3fb3fc851b876046039509e18e0c7485f2c"
       url: "https://pub.dev"
     source: hosted
-    version: "3.7.2"
-  process:
-    dependency: transitive
-    description:
-      name: process
-      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.2.4"
+    version: "3.7.3"
   shared_preferences:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: "5949029e70abe87f75cfe59d17bf5c397619c4b74a099b10116baeb34786fad9"
+      sha256: "0344316c947ffeb3a529eac929e1978fcd37c26be4e8468628bac399365a3ca1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.17"
+    version: "2.2.0"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "955e9736a12ba776bdd261cf030232b30eadfcd9c79b32a3250dd4a494e8c8f7"
+      sha256: fe8401ec5b6dcd739a0fe9588802069e608c3fdbfd3c3c93e546cf2f90438076
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.15"
+    version: "2.2.0"
   shared_preferences_foundation:
     dependency: transitive
     description:
       name: shared_preferences_foundation
-      sha256: "2b55c18636a4edc529fa5cd44c03d3f3100c00513f518c5127c951978efcccd0"
+      sha256: f39696b83e844923b642ce9dd4bd31736c17e697f6731a5adf445b1274cf3cd4
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.3.2"
   shared_preferences_linux:
     dependency: transitive
     description:
       name: shared_preferences_linux
-      sha256: f8ea038aa6da37090093974ebdcf4397010605fd2ff65c37a66f9d28394cb874
+      sha256: "71d6806d1449b0a9d4e85e0c7a917771e672a3d5dc61149cc9fac871115018e1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.3.0"
   shared_preferences_platform_interface:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
-      sha256: da9431745ede5ece47bc26d5d73a9d3c6936ef6945c101a5aca46f62e52c1cf3
+      sha256: "23b052f17a25b90ff2b61aad4cc962154da76fb62848a9ce088efe30d7c50ab1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.3.0"
   shared_preferences_web:
     dependency: transitive
     description:
       name: shared_preferences_web
-      sha256: a4b5bc37fe1b368bbc81f953197d55e12f49d0296e7e412dfe2d2d77d6929958
+      sha256: "7347b194fb0bbeb4058e6a4e87ee70350b6b2b90f8ac5f8bd5b3a01548f6d33a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.4"
+    version: "2.2.0"
   shared_preferences_windows:
     dependency: transitive
     description:
       name: shared_preferences_windows
-      sha256: "5eaf05ae77658d3521d0e993ede1af962d4b326cd2153d312df716dc250f00c9"
+      sha256: f95e6a43162bce43c9c3405f3eb6f39e5b5d11f65fab19196cf8225e2777624d
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.3.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -425,18 +425,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.5.1"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   vector_math:
     dependency: transitive
     description:
@@ -449,34 +449,34 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: c9ebe7ee4ab0c2194e65d3a07d8c54c5d00bb001b76081c4a04cdb8448b59e46
+      sha256: f2add6fa510d3ae152903412227bda57d0d5a8da61d2c39c1fb022c9429a41c0
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "5.0.6"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
-      sha256: ee1505df1426458f7f60aac270645098d318a8b4766d85fde75f76f2e21807d1
+      sha256: e0b1147eec179d3911f1f19b59206448f78195ca1d20514134e10641b7d7fbff
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   xml:
     dependency: transitive
     description:
       name: xml
-      sha256: "979ee37d622dec6365e2efa4d906c37470995871fe9ae080d967e192d88286b5"
+      sha256: "5bc72e1e45e941d825fd7468b9b4cc3b9327942649aeb6fc5cdbf135f0a86e84"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.2"
+    version: "6.3.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
+      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
 sdks:
-  dart: ">=2.19.1 <3.0.0"
-  flutter: ">=3.0.0"
+  dart: ">=3.0.0 <3.0.7"
+  flutter: ">=3.3.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   system_proxy: 0.1.0
   shared_preferences: ^2.0.15
   flutter_launcher_icons: ^0.13.0
+  fl_chart: ^0.63.0
   intl: ^0.18.0
   path:
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.19.1 <3.0.0"
+  sdk: ">=2.19.1 <3.0.7"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -100,4 +100,4 @@ flutter:
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/custom-fonts/#from-packages
   assets:
-    - assets/
+    - assets/images/


### PR DESCRIPTION
## 実装内容

- 測定結果確認画面を追加

## 確認手順

- ビルドして実機インストールもしくはシミュレータにインストール
- ログイン
- 端末一覧から端末を選択
- グラフが表示されることを確認

## スクリーンショット

- 動作確認

https://github.com/mktkhr/stamp-iot-flutter/assets/51685340/0c6ba8a5-5abe-414f-a8df-001863955e94

## 確認した環境

- M1 MacBook Pro
- macOS Monterey version 13.3.1

resolve #12 